### PR TITLE
Segfault & leak issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .minishell_history
+*/**/*.swp

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,9 @@ CXXFLAGS = -Wall -Werror -Wextra
 
 NAME	= minishell
 
+debug:	CXXFLAGS += -fsanitize=address -g3
+debug:	all
+
 all:	$(NAME)
 
 $(NAME): $(OBJ)
@@ -88,7 +91,7 @@ $(DIR_OBJ)%.o: $(DIR_CMD)%.c
 	$(CXX) $(CXXFLAGS) -c $< -I$(DIR_INC)
 	@mkdir -pv $(DIR_OBJ)
 	@mv -v $(@F) $(@D)
-
+	
 $(DIR_OBJ)%.o: $(DIR_UTILS)%.c
 	$(CXX) $(CXXFLAGS) -c $< -I$(DIR_INC)
 	@mkdir -pv $(DIR_OBJ)

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ CXXFLAGS = -Wall -Werror -Wextra
 NAME	= minishell
 
 debug:	CXXFLAGS += -fsanitize=address -g3
-debug:	all
+debug:	fclean all
 
 all:	$(NAME)
 

--- a/src/parser/parser.c
+++ b/src/parser/parser.c
@@ -85,7 +85,10 @@ char	*input_cleaner(char *str)
 	len = 0;
 	len = input_len(str, &len, quote);
 	if (len == -1)
+	{
+		free(str_start);
 		return (0);
+	}
 	clean_input = (char *)malloc((len + 1) * sizeof(char));
 	if (!clean_input)
 		exit(EXIT_FAILURE);

--- a/src/parser/parser_utils_2.c
+++ b/src/parser/parser_utils_2.c
@@ -40,7 +40,7 @@ int	is_word(char *input)
 
 int	is_blank(char input)
 {
-	if (!ft_strrchr(" \t\v\f\r", input))
+	if (!input || !ft_strrchr(" \t\v\f\r", input))
 		return (0);
 	return (1);
 }


### PR DESCRIPTION
Minishell segfaults when compiled with stricts memeory access rules due to bug in is_blank character check function, with false positive when passed a nullchar.

Also found a leak when input is discarded with a open quote.